### PR TITLE
feat: Add dropdown menu and sticky phone number to navigation

### DIFF
--- a/src/_data/navigation.yaml
+++ b/src/_data/navigation.yaml
@@ -2,6 +2,13 @@
 items:
   - text: Menu One
     url: "#"
+  - text: Services # New dropdown menu
+    url: "#" # Or the main page for services
+    dropdown:
+      - text: Service A
+        url: "/services/a"
+      - text: Service B
+        url: "/services/b"
   - text: Menu Two
     url: "#"
   - text: Menu Three

--- a/src/_includes/partials/navbar.html
+++ b/src/_includes/partials/navbar.html
@@ -21,13 +21,40 @@
 
                 <ul class="pt-6 lg:pt-0 list-reset lg:flex justify-end flex-1 items-center">
                     {% for item in navigation.items %}
-                        <li class="nav__item mr-3">
-                            <a @click="isOpen = false" class="text-ml inline-block text-gray-500 no-underline hover:text-indigo-500 py-2 px-4" href="{{ item.url }}">{{ item.text }}</a>
-                        </li>
+                        {% if item.dropdown %}
+                            <li class="nav__item mr-3 relative" x-data="{ open: false }" @mouseleave="open = false">
+                                <a  @mouseover="open = true" 
+                                    @click.prevent="open = !open; if (item.url !== '#') { isOpen = false; window.location.href = item.url; }"
+                                    class="text-ml inline-flex items-center text-gray-500 no-underline hover:text-indigo-500 py-2 px-4 cursor-pointer" 
+                                    :href="item.url">
+                                    {{ item.text }}
+                                    <svg class="h-4 w-4 fill-current text-gray-500 ml-1 transform transition-transform duration-200" :class="{'rotate-180': open, 'rotate-0': !open}" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M7 10l5 5 5-5H7z"/></svg>
+                                </a>
+                                <ul x-show="open" @click.away="open = false" 
+                                    class="lg:absolute left-0 mt-2 py-2 w-48 bg-white rounded-md shadow-xl z-20 text-left">
+                                    {% for sub_item in item.dropdown %}
+                                        <li>
+                                            <a @click="isOpen = false; open = false" class="block px-4 py-2 text-gray-800 hover:bg-indigo-500 hover:text-white" href="{{ sub_item.url }}">{{ sub_item.text }}</a>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            </li>
+                        {% else %}
+                            <li class="nav__item mr-3">
+                                <a @click="isOpen = false" class="text-ml inline-block text-gray-500 no-underline hover:text-indigo-500 py-2 px-4" href="{{ item.url }}">{{ item.text }}</a>
+                            </li>
+                        {% endif %}
                     {% endfor %}
                 </ul>
 
             {% endif %}
+        </div>
+
+        <!-- Phone number -->
+        <div class="hidden lg:flex items-center ml-4"> <!-- hidden on mobile, flex on desktop. ml-4 for spacing -->
+            <a href="tel:+15551234567" class="text-ml text-indigo-500 no-underline hover:text-indigo-700 py-2 px-4">
+                +1 (555) 123-4567
+            </a>
         </div>
     </nav>
 </div>


### PR DESCRIPTION
This commit introduces two enhancements to the main navigation bar:

1.  **Dropdown Navigation Menu:**
    *   Modified `src/_data/navigation.yaml` to support nested items for dropdowns.
    *   Updated `src/_includes/partials/navbar.html` to render dropdown menus.
    *   Dropdowns are implemented using Alpine.js for toggle functionality (hover on desktop, click on mobile).
    *   Styled with Tailwind CSS, ensuring responsiveness and integration with the existing mobile menu.

2.  **Sticky Phone Number:**
    *   Added a phone number link to the far right of the navigation bar in `src/_includes/partials/navbar.html`.
    *   The phone number is sticky, remaining visible on scroll as part of the fixed navigation bar on larger screens (`lg:fixed`).
    *   Styled with Tailwind CSS, and hidden on mobile screens to maintain a clean layout.

No custom CSS was required as Tailwind CSS utilities were sufficient for styling and responsiveness.